### PR TITLE
Fix: Quote parameters to prevent breaking of command

### DIFF
--- a/src/task/dump/Dump.php
+++ b/src/task/dump/Dump.php
@@ -43,12 +43,12 @@ final class Dump implements iDump {
   public function __invoke() : void {
     $dumpfile = $this->dumpfile->getFilename();
 
-    $ignoredTableString = implode(' ', array_map(static fn(string $table) => sprintf('--ignore-table %s', $table), $this->database->getTablesToIgnore()));
+    $ignoredTableString = implode(' ', array_map(static fn(string $table) => sprintf('--ignore-table "%s"', $table), $this->database->getTablesToIgnore()));
 
     $name = $this->database->getName();
 
-    $baseCommand = sprintf('mysqldump --user=%s --password=%s --host=%s --port=%d --comments=false --disable-keys --no-autocommit --single-transaction', $this->database->getUser(), $this->database->getPassword(), $this->database->getHost(), $this->database->getPort());
-    $this->deployerFunctions->run(sprintf('%s --add-drop-table --routines --no-data %s > %s', $baseCommand, $name, $dumpfile));
-    $this->deployerFunctions->run(sprintf('%s --no-create-info --extended-insert %s %s >> %s', $baseCommand, $ignoredTableString, $name, $dumpfile));
+    $baseCommand = sprintf('mysqldump --user="%s" --password="%s" --host="%s" --port=%d --comments=false --disable-keys --no-autocommit --single-transaction', $this->database->getUser(), $this->database->getPassword(), $this->database->getHost(), $this->database->getPort());
+    $this->deployerFunctions->run(sprintf('%s --add-drop-table --routines --no-data "%s" > "%s"', $baseCommand, $name, $dumpfile));
+    $this->deployerFunctions->run(sprintf('%s --no-create-info --extended-insert %s "%s" >> "%s"', $baseCommand, $ignoredTableString, $name, $dumpfile));
   }
 }

--- a/src/task/import/Import.php
+++ b/src/task/import/Import.php
@@ -43,8 +43,8 @@ final class Import implements iImport {
    */
   public function __invoke() : void {
     $name = $this->database->getName();
-    $baseCommand = sprintf('mysql --user=%s --password=%s --host=%s --port=%s', $this->database->getUser(), $this->database->getPassword(), $this->database->getHost(), $this->database->getPort());
+    $baseCommand = sprintf('mysql --user="%s" --password="%s" --host="%s" --port=%d', $this->database->getUser(), $this->database->getPassword(), $this->database->getHost(), $this->database->getPort());
     $this->deployerFunctions->run(sprintf('%s -e "CREATE DATABASE IF NOT EXISTS %s;"', $baseCommand, $name));
-    $this->deployerFunctions->run(sprintf('%s %s < %s;', $baseCommand, $name, $this->dumpfile->getFilename()));
+    $this->deployerFunctions->run(sprintf('%s "%s" < "%s";', $baseCommand, $name, $this->dumpfile->getFilename()));
   }
 }

--- a/test/task/dump/DumpTest.php
+++ b/test/task/dump/DumpTest.php
@@ -42,8 +42,8 @@ final class DumpTest extends TestCase {
     $this->sut->dumpfile = $this->createConfiguredMock(iDumpfile::class, ['getFilename' => '/some/folder/file']);
 
     $this->sut->deployerFunctions = \Mockery::mock(iRun::class);
-    $this->sut->deployerFunctions->allows('run')->once()->ordered()->with('mysqldump --user=myUser --password=topSecret --host=someHost --port=1234 --comments=false --disable-keys --no-autocommit --single-transaction --add-drop-table --routines --no-data myDatabase > /some/folder/file');
-    $this->sut->deployerFunctions->allows('run')->once()->ordered()->with('mysqldump --user=myUser --password=topSecret --host=someHost --port=1234 --comments=false --disable-keys --no-autocommit --single-transaction --no-create-info --extended-insert --ignore-table ignore1 --ignore-table ignore2 myDatabase >> /some/folder/file');
+    $this->sut->deployerFunctions->allows('run')->once()->ordered()->with('mysqldump --user="myUser" --password="topSecret" --host="someHost" --port=1234 --comments=false --disable-keys --no-autocommit --single-transaction --add-drop-table --routines --no-data "myDatabase" > "/some/folder/file"');
+    $this->sut->deployerFunctions->allows('run')->once()->ordered()->with('mysqldump --user="myUser" --password="topSecret" --host="someHost" --port=1234 --comments=false --disable-keys --no-autocommit --single-transaction --no-create-info --extended-insert --ignore-table "ignore1" --ignore-table "ignore2" "myDatabase" >> "/some/folder/file"');
 
     $this->sut->__invoke();
   }

--- a/test/task/import/ImportTest.php
+++ b/test/task/import/ImportTest.php
@@ -32,8 +32,8 @@ final class ImportTest extends TestCase {
     $this->sut->dumpfile = $this->createConfiguredMock(iDumpfile::class, ['getFilename' => '/some/folder/file']);
 
     $this->sut->deployerFunctions = Mockery::mock(iRun::class);
-    $this->sut->deployerFunctions->allows('run')->once()->ordered()->with('mysql --user=myUser --password=topSecret --host=myHost --port=1234 -e "CREATE DATABASE IF NOT EXISTS myDatabase;"');
-    $this->sut->deployerFunctions->allows('run')->once()->ordered()->with('mysql --user=myUser --password=topSecret --host=myHost --port=1234 myDatabase < /some/folder/file;');
+    $this->sut->deployerFunctions->allows('run')->once()->ordered()->with('mysql --user="myUser" --password="topSecret" --host="myHost" --port=1234 -e "CREATE DATABASE IF NOT EXISTS myDatabase;"');
+    $this->sut->deployerFunctions->allows('run')->once()->ordered()->with('mysql --user="myUser" --password="topSecret" --host="myHost" --port=1234 "myDatabase" < "/some/folder/file";');
 
     $this->sut->__invoke();
   }


### PR DESCRIPTION
This PR quotes all parameters for commands since special chars might otherwise break the command when run.